### PR TITLE
fix: replace non-existent lower() function with platform-specific OS name detection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,8 +78,33 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Set OS name (Windows)
+      id: os-windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        "name=windows" >> $env:GITHUB_OUTPUT
+
+    - name: Set OS name (Unix)
+      id: os-unix
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        case "${{ runner.os }}" in
+          "Linux")
+            echo "name=linux" >> $GITHUB_OUTPUT
+            ;;
+          "macOS")
+            echo "name=macos" >> $GITHUB_OUTPUT
+            ;;
+          *)
+            echo "Unsupported OS: ${{ runner.os }}"
+            exit 1
+            ;;
+        esac
+
     - name: Run EditorConfig Lint
-      uses: ./action-${{ lower(runner.os) }}.yml
+      uses: ./action-${{ steps.os-windows.outputs.name || steps.os-unix.outputs.name }}.yml
       with:
         version: ${{ inputs.version }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
Fixes the action failure caused by using the non-existent `lower()` function.

## Problem
The previous implementation used `lower(runner.os)` which doesn't exist in GitHub Actions expressions, causing action failures.

## Solution
- Add separate steps for Windows (PowerShell) and Unix (bash) to detect and set the lowercase OS name
- Windows step: Uses PowerShell to set `name=windows`
- Unix step: Uses bash to handle both Linux (`name=linux`) and macOS (`name=macos`)
- Main step: Uses output variable with fallback via `||` operator

## Technical Details
- `steps.os-windows.outputs.name` will be set on Windows runners
- `steps.os-unix.outputs.name` will be set on Linux/macOS runners  
- The expression `steps.os-windows.outputs.name || steps.os-unix.outputs.name` ensures the correct value is used

This maintains full cross-platform compatibility while using proper GitHub Actions syntax.